### PR TITLE
Music

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 tailwindcss*
+
+# 음악 파일 무시
+public/music/

--- a/frontend/src/data/musicLibrary.js
+++ b/frontend/src/data/musicLibrary.js
@@ -1,0 +1,37 @@
+export const musicLibrary = [
+  {
+    id: 1,
+    title: "wedding-01",
+    data: "/music/wedding-01.mp3"
+  },
+  {
+    id: 2,
+    title: "wedding-02",
+    data: "/music/wedding-02.mp3"
+  },
+  {
+    id: 3,
+    title: "wedding-03",
+    data: "/music/wedding-03.mp3"
+  },
+  {
+    id: 4,
+    title: "wedding-04",
+    data: "/music/wedding-04.mp3"
+  },
+  {
+    id: 5,
+    title: "wedding-05",
+    data: "/music/wedding-05.mp3"
+  },
+  {
+    id: 6,
+    title: "wedding-06",
+    data: "/music/wedding-06.mp3"
+  },
+  {
+    id: 7,
+    title: "wedding-07",
+    data: "/music/wedding-07.mp3"
+  }
+];

--- a/frontend/src/pages/NoCodeEditor.jsx
+++ b/frontend/src/pages/NoCodeEditor.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import * as Y from 'yjs';
 import { WebsocketProvider } from 'y-websocket';
-import { useParams } from 'react-router-dom';
+import { useParams, useLocation } from 'react-router-dom';
 
 // 모듈화된 컴포넌트들
 import ComponentLibrary from './NoCodeEditor/ComponentLibrary';

--- a/frontend/src/pages/NoCodeEditor/ComponentEditor.jsx
+++ b/frontend/src/pages/NoCodeEditor/ComponentEditor.jsx
@@ -9,6 +9,7 @@ import WeddingContactEditor from './ComponentEditors/WeddingContactEditor.jsx';
 import ImageEditor from './ComponentEditors/ImageEditor.jsx';
 import BankAccountEditor from './ComponentEditors/BankAccountEditor.jsx';
 import WeddingInviteEditor from './ComponentEditors/WeddingInviteEditor';
+import MusicPlayerEditor from './ComponentEditors/MusicPlayerEditor';
 
 
 
@@ -38,6 +39,8 @@ export default function ComponentEditor({ selectedComp, onUpdate }) {
             return <BankAccountEditor selectedComp={selectedComp} onUpdate={onUpdate} />;
         case 'weddingInvite':
             return <WeddingInviteEditor selectedComp={selectedComp} onUpdate={onUpdate} />;
+        case 'musicPlayer':
+            return <MusicPlayerEditor selectedComp={selectedComp} onUpdate={onUpdate} />;
         default:
             return <p>Select a component to edit its properties.</p>;
     }

--- a/frontend/src/pages/NoCodeEditor/ComponentEditors/MusicEditor.jsx
+++ b/frontend/src/pages/NoCodeEditor/ComponentEditors/MusicEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { musicLibrary } from '../../../data/musicLibrary';
 
 export default function MusicEditor({ selectedComp, onUpdate }) {
@@ -25,6 +25,9 @@ export default function MusicEditor({ selectedComp, onUpdate }) {
 
     // 미리듣기 핸들러
     const togglePreview = (music) => {
+        // 다른 오디오 정지
+        window.dispatchEvent(new Event('stopAllMusic'));
+
         if (isPreviewPlaying && previewMusicId === music.id) {
             previewAudioRef.current?.pause();
             setIsPreviewPlaying(false);
@@ -38,6 +41,17 @@ export default function MusicEditor({ selectedComp, onUpdate }) {
             }
         }
     };
+
+    // stopAllMusic 이벤트 수신 시 미리듣기 정지
+    useEffect(() => {
+        const stopPreview = () => {
+            previewAudioRef.current?.pause();
+            setIsPreviewPlaying(false);
+            setPreviewMusicId(null);
+        };
+        window.addEventListener('stopAllMusic', stopPreview);
+        return () => window.removeEventListener('stopAllMusic', stopPreview);
+    }, []);
 
     return (
         <div>

--- a/frontend/src/pages/NoCodeEditor/ComponentEditors/MusicEditor.jsx
+++ b/frontend/src/pages/NoCodeEditor/ComponentEditors/MusicEditor.jsx
@@ -1,0 +1,134 @@
+import React, { useState, useRef } from 'react';
+import { musicLibrary } from '../../../data/musicLibrary';
+
+export default function MusicEditor({ selectedComp, onUpdate }) {
+    const previewAudioRef = useRef(null);
+    const [isPreviewPlaying, setIsPreviewPlaying] = useState(false);
+    const [previewMusicId, setPreviewMusicId] = useState(null);
+
+    // 음악 선택 핸들러
+    const selectMusic = (music) => {
+        const updatedComp = {
+            ...selectedComp,
+            props: {
+                ...selectedComp.props,
+                selectedMusicId: music.id,
+                musicData: music.data,
+                musicTitle: music.title,
+                showTitle: false // 음악 제목 표시 항상 false로 고정
+            }
+        };
+        if (typeof onUpdate === 'function') {
+            onUpdate(updatedComp);
+        }
+    };
+
+    // 미리듣기 핸들러
+    const togglePreview = (music) => {
+        if (isPreviewPlaying && previewMusicId === music.id) {
+            previewAudioRef.current?.pause();
+            setIsPreviewPlaying(false);
+            setPreviewMusicId(null);
+        } else {
+            if (previewAudioRef.current) {
+                previewAudioRef.current.src = music.data;
+                previewAudioRef.current.play().catch(console.error);
+                setIsPreviewPlaying(true);
+                setPreviewMusicId(music.id);
+            }
+        }
+    };
+
+    return (
+        <div>
+            {/* 미리듣기용 오디오 */}
+            <audio
+                ref={previewAudioRef}
+                onEnded={() => {
+                    setIsPreviewPlaying(false);
+                    setPreviewMusicId(null);
+                }}
+            />
+
+            {/* 컴포넌트 정보 */}
+            <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                marginBottom: 20,
+                padding: '8px 12px',
+                backgroundColor: '#f0f2f5',
+                borderRadius: 6
+            }}>
+                <span style={{ fontSize: 16 }}>🎵</span>
+                <div>
+                    <div style={{ fontSize: 13, fontWeight: 600, color: '#1d2129' }}>
+                        Music Player
+                    </div>
+                </div>
+            </div>
+
+            {/* 음악 라이브러리 */}
+            <div style={{ marginBottom: 20 }}>
+                <h4 style={{
+                    fontSize: '14px',
+                    fontWeight: 600,
+                    color: '#1d2129',
+                    marginBottom: '12px'
+                }}>
+                    🎼 음악 선택 ({musicLibrary.length}곡)
+                </h4>
+
+                <div style={{ maxHeight: '400px', overflowY: 'auto' }}>
+                    {musicLibrary.map(music => (
+                        <div
+                            key={music.id}
+                            style={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                padding: '8px 12px',
+                                border: selectedComp.props.selectedMusicId === music.id
+                                    ? '2px solid #3B4EFF'
+                                    : '1px solid #ddd',
+                                borderRadius: 6,
+                                marginBottom: 6,
+                                backgroundColor: selectedComp.props.selectedMusicId === music.id
+                                    ? '#f0f4ff'
+                                    : '#fff',
+                                cursor: 'pointer'
+                            }}
+                            onClick={() => selectMusic(music)}
+                        >
+                            <div style={{ flex: 1 }}>
+                                <div style={{ fontWeight: 600, fontSize: '14px' }}>
+                                    {music.title}
+                                </div>
+                            </div>
+                            {/* 미리듣기 버튼 */}
+                            <button
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    togglePreview(music);
+                                }}
+                                style={{
+                                    background: 'none',
+                                    border: 'none',
+                                    borderRadius: 0,
+                                    color: '#222',
+                                    cursor: 'pointer',
+                                    fontSize: '20px',
+                                    width: 'auto',
+                                    height: 'auto',
+                                    padding: 0,
+                                    marginLeft: 8
+                                }}
+                            >
+                                {isPreviewPlaying && previewMusicId === music.id ? '⏹' : '▶'}
+                            </button>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/NoCodeEditor/ComponentEditors/index.js
+++ b/frontend/src/pages/NoCodeEditor/ComponentEditors/index.js
@@ -14,3 +14,4 @@ export { default as CalendarEditor } from './CalendarEditor';
 export { default as BankAccountEditor } from './BankAccountEditor';
 export { default as CommentEditor } from './CommentEditor';
 export { default as WeddingInviteEditor} from "./WeddingInviteEditor";
+export { default as MusicEditor } from "./MusicEditor";

--- a/frontend/src/pages/NoCodeEditor/ComponentRenderers/MusicRenderer.jsx
+++ b/frontend/src/pages/NoCodeEditor/ComponentRenderers/MusicRenderer.jsx
@@ -28,6 +28,9 @@ export default function MusicRenderer({ comp, isEditor = false }) {
 
     // 재생/일시정지 토글
     const togglePlay = () => {
+        // 다른 오디오 정지
+        window.dispatchEvent(new Event('stopAllMusic'));
+
         if (!musicData) return; // 음악 없으면 아무 동작 안함
         if (!audioRef.current) return;
         if (isPlaying) {
@@ -51,6 +54,16 @@ export default function MusicRenderer({ comp, isEditor = false }) {
             audio.removeEventListener('pause', onPause);
         };
     }, [musicData]);
+
+    // stopAllMusic 이벤트 수신 시 음악 정지
+    useEffect(() => {
+        const stopMusic = () => {
+            audioRef.current?.pause();
+            setIsPlaying(false);
+        };
+        window.addEventListener('stopAllMusic', stopMusic);
+        return () => window.removeEventListener('stopAllMusic', stopMusic);
+    }, []);
 
     return (
         <div style={{

--- a/frontend/src/pages/NoCodeEditor/ComponentRenderers/MusicRenderer.jsx
+++ b/frontend/src/pages/NoCodeEditor/ComponentRenderers/MusicRenderer.jsx
@@ -1,0 +1,88 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+export default function MusicRenderer({ comp, isEditor = false }) {
+    const audioRef = useRef(null);
+    const [isPlaying, setIsPlaying] = useState(false);
+
+    const props = comp?.props || {};
+    const {
+        musicData = null,
+        autoPlay = false,
+        loop = true,
+        volume = 0.7
+    } = props;
+
+    useEffect(() => {
+        if (audioRef.current) {
+            audioRef.current.volume = volume;
+        }
+    }, [volume]);
+
+    useEffect(() => {
+        if (autoPlay && musicData && audioRef.current && !isEditor) {
+            setTimeout(() => {
+                audioRef.current.play().catch(() => {});
+            }, 500);
+        }
+    }, [musicData, autoPlay, isEditor]);
+
+    // 재생/일시정지 토글
+    const togglePlay = () => {
+        if (!musicData) return; // 음악 없으면 아무 동작 안함
+        if (!audioRef.current) return;
+        if (isPlaying) {
+            audioRef.current.pause();
+        } else {
+            audioRef.current.play().catch(() => {});
+        }
+        setIsPlaying(!isPlaying);
+    };
+
+    // 오디오 이벤트 리스너
+    useEffect(() => {
+        const audio = audioRef.current;
+        if (!audio) return;
+        const onPlay = () => setIsPlaying(true);
+        const onPause = () => setIsPlaying(false);
+        audio.addEventListener('play', onPlay);
+        audio.addEventListener('pause', onPause);
+        return () => {
+            audio.removeEventListener('play', onPlay);
+            audio.removeEventListener('pause', onPause);
+        };
+    }, [musicData]);
+
+    return (
+        <div style={{
+            width: '60px',
+            height: '60px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center'
+        }}>
+            {musicData && (
+                <audio
+                    ref={audioRef}
+                    src={musicData}
+                    preload="metadata"
+                    style={{ display: 'none' }}
+                    autoPlay={autoPlay}
+                    loop={loop}
+                />
+            )}
+            <button
+                onClick={togglePlay}
+                style={{
+                    background: 'none',
+                    border: 'none',
+                    fontSize: 40,
+                    color: '#222',
+                    cursor: 'pointer',
+                    padding: 0
+                }}
+            >
+                {isPlaying ? '⏸' : '▶'}
+            </button>
+        </div>
+    );
+}

--- a/frontend/src/pages/NoCodeEditor/ComponentRenderers/index.js
+++ b/frontend/src/pages/NoCodeEditor/ComponentRenderers/index.js
@@ -11,6 +11,7 @@ export { default as SlideGalleryRenderer } from "./SlideGalleryRenderer";
 export { default as MapView } from "./MapView";
 export { default as MapInfoRenderer } from './MapInfoRenderer';
 export { default as WeddingInviteRenderer } from './WeddingInviteRenderer'; 
+export { default as MusicRenderer } from './MusicRenderer';
 
 
 // 개별 import (getRendererByType 함수에서 사용)
@@ -26,6 +27,7 @@ import SlideGalleryRenderer from "./SlideGalleryRenderer";
 import MapView from "./MapView";
 import MapInfoRenderer from './MapInfoRenderer';
 import WeddingInviteRenderer from './WeddingInviteRenderer'; 
+import MusicRenderer from './MusicRenderer';
 
 
 // 컴포넌트 타입별 렌더러 매핑 함수
@@ -55,6 +57,8 @@ export function getRendererByType(type) {
       return MapInfoRenderer;
     case 'weddingInvite':
       return WeddingInviteRenderer;
+    case 'musicPlayer':
+      return MusicRenderer;
     default:
       return null;
   }

--- a/frontend/src/pages/NoCodeEditor/Inspector.jsx
+++ b/frontend/src/pages/NoCodeEditor/Inspector.jsx
@@ -35,6 +35,8 @@ function Inspector({ selectedComp, onUpdate, color, nickname, roomId }) {
         return ComponentEditors.CommentEditor;
       case 'weddingInvite':
         return ComponentEditors.WeddingInviteEditor;
+      case 'musicPlayer':
+        return ComponentEditors.MusicEditor;
       default:
         console.warn(`Unknown component type: ${componentType}`);
         return null;
@@ -53,7 +55,8 @@ function Inspector({ selectedComp, onUpdate, color, nickname, roomId }) {
       dday: '📅',
       weddingContact: '💒',
       bankAccount: '🏦',
-      comment: '💬'
+      comment: '💬',
+      musicPlayer: '🎵'
     };
     return icons[type] || '📦';
   };
@@ -73,7 +76,8 @@ function Inspector({ selectedComp, onUpdate, color, nickname, roomId }) {
       slideGallery: 'Slide Gallery',
       calendar: 'Calendar',
       bankAccount: 'Bank Account',
-      comment: 'Comment'
+      comment: 'Comment',
+      musicPlayer: 'Music Player'  
     };
     return labels[type] || 'Component';
   };

--- a/frontend/src/pages/NoCodeEditor/components/CanvasComponent.jsx
+++ b/frontend/src/pages/NoCodeEditor/components/CanvasComponent.jsx
@@ -15,6 +15,7 @@ import BankAccountRenderer from '../ComponentRenderers/BankAccountRenderer';
 import CommentRenderer from '../ComponentRenderers/CommentRenderer';
 import { clamp, resolveCollision, calculateSnapPosition, calculateSnapLines } from '../utils/editorUtils';
 import WeddingInviteRenderer from '../ComponentRenderers/WeddingInviteRenderer';
+import MusicRenderer from '../ComponentRenderers/MusicRenderer';
 
 
 // 그리드 크기 상수
@@ -169,6 +170,8 @@ function CanvasComponent({
         return <CommentRenderer comp={comp} isEditor={true} viewport={viewport} />;
       case 'weddingInvite':
         return <WeddingInviteRenderer comp={comp} isEditor={true} viewport={viewport} />;
+      case 'musicPlayer':
+        return <MusicRenderer comp={comp} isEditor={true} onUpdate={onUpdate} viewport={viewport} />;
       default:
         return <span>{comp.props.text}</span>;
     }

--- a/frontend/src/pages/NoCodeEditor/utils/editorUtils.js
+++ b/frontend/src/pages/NoCodeEditor/utils/editorUtils.js
@@ -87,7 +87,8 @@ export function getComponentDimensions(type) {
     mapInfo: { defaultWidth: 300, defaultHeight: 200, minWidth: 250, minHeight: 150 },
     calendar: { defaultWidth: 350, defaultHeight: 400, minWidth: 300, minHeight: 350 },
     bankAccount: { defaultWidth: 300, defaultHeight: 200, minWidth: 250, minHeight: 150 },
-    comment: { defaultWidth: 300, defaultHeight: 200, minWidth: 250, minHeight: 150 }
+    comment: { defaultWidth: 300, defaultHeight: 200, minWidth: 250, minHeight: 150 },
+    musicPlayer: { defaultWidth: 150, defaultHeight: 150, minWidth: 100, minHeight: 100 }
   };
   return dimensions[type] || { defaultWidth: 150, defaultHeight: 50, minWidth: 100, minHeight: 50 };
 }

--- a/frontend/src/pages/components/definitions/index.js
+++ b/frontend/src/pages/components/definitions/index.js
@@ -13,6 +13,7 @@ import calendarDef from './calendar.json';
 import bankAccount from './bank-account.json';
 import commentDef from './comment.json';
 import weddingInviteDef from './wedding-invite.json';
+import musicDef from './music.json';
 
 export const ComponentList = [
   buttonDef,
@@ -29,7 +30,8 @@ export const ComponentList = [
   bankAccount,
   calendarDef,
   commentDef,
-  weddingInviteDef
+  weddingInviteDef,
+  musicDef
 ];
 
 // 기존 코드와의 호환성을 위해 ComponentDefinitions도 export

--- a/frontend/src/pages/components/definitions/music.json
+++ b/frontend/src/pages/components/definitions/music.json
@@ -1,0 +1,15 @@
+{
+  "type": "musicPlayer",
+  "label": "🎵 음악 플레이어",
+  "defaultProps": {
+    "selectedMusicId": null,
+    "musicData": null,
+    "musicTitle": "음악을 선택해주세요",
+    "buttonSize": "medium",
+    "buttonColor": "#ff6b9d",
+    "showTitle": true,
+    "autoPlay": false,
+    "loop": true,
+    "volume": 0.7
+  }
+}


### PR DESCRIPTION
## 📋 PR 요약

음악 컴포넌트 생성 완료

## 📋 Issue 번호

- close #84 

## 🔍 변경 사항

- 변경 1: 최종 풀리퀘스트 직전에 미리듣기와 캔버스에 렌더링된 컴포넌트가 동시 재생이 되는거를 인지하여 코드를 재수정했음
## 📢 공유하고 싶은 내용

최종 풀리퀘스트 직전에 미리듣기와 캔버스에 렌더링된 컴포넌트가 동시 재생이 되길래 코드를 재수정했음
음악은 frontend폴더에 frontend/public/music폴더를 생성해서 저장함
frontend/src/data/musicLibrary.js도 따로 생성함
그외는 기존 컴포넌트 생성 방식과 동일하게 구현함
frontend/.gitignore에 public/music/ 했음

## 📎 스크린샷
![스크린샷 2025-07-02 223545](https://github.com/user-attachments/assets/6f860cad-0b10-48dc-ba78-d000c359d2ab)
