### PR TITLE
🔧 Disable conflicting editor workflow

### DIFF
--- a/.github/workflows/5pointers-editor-deploy.yml.disabled
+++ b/.github/workflows/5pointers-editor-deploy.yml.disabled
@@ -1,20 +1,24 @@
-name: Deploy Frontend Editor
+name: Deploy Frontend Editor (DISABLED)
+
+# 이 워크플로우는 비활성화되었습니다.
+# 5pointers-frontend-deploy.yml을 대신 사용합니다.
 
 on:
-  push:
-    branches: [ main, develop ]
-    paths:
-      - 'my-web-builder/apps/editor/**'
-      - 'my-web-builder/packages/**'
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'my-web-builder/apps/editor/**'
-      - 'my-web-builder/packages/**'
+  # push:
+  #   branches: [ main, develop ]
+  #   paths:
+  #     - 'my-web-builder/apps/editor/**'
+  #     - 'my-web-builder/packages/**'
+  # pull_request:
+  #   branches: [ main ]
+  #   paths:
+  #     - 'my-web-builder/apps/editor/**'
+  #     - 'my-web-builder/packages/**'
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    if: false  # 항상 false로 설정하여 실행 방지
     steps:
     - uses: actions/checkout@v3
     
@@ -46,7 +50,7 @@ jobs:
   deploy:
     needs: test
     runs-on: [self-hosted, frontend-server]
-    if: github.ref == 'refs/heads/main'
+    if: false  # 항상 false로 설정하여 실행 방지
     
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
- Disable 5pointers-editor-deploy.yml that was causing TypeScript errors
- This workflow was running instead of the correct frontend workflow
- Now only 5pointers-frontend-deploy.yml will handle frontend deployments

## 📋 PR 요약

<!-- 작업 내용 한 줄로 요약 -->

## 📋 Issue 번호

- close # 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

## 📎 스크린샷
