### PR TITLE
🔒 Y.js 서버 SSL 인증서 설정 완료

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           cd my-web-builder/apps/frontend
           echo "VITE_API_URL=https://pagecube.net/api" > .env.production
-          echo "VITE_YJS_WEBSOCKET_URL=wss://pagecube.net/yjs" >> .env.production
+          echo "VITE_YJS_WEBSOCKET_URL=wss://3.35.50.227:1235" >> .env.production
           echo "VITE_SUBDOMAIN_URL=http://3.35.141.231:3001" >> .env.production
           echo "VITE_GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env.production
           echo "VITE_KAKAO_CLIENT_ID=${{ secrets.KAKAO_JAVASCRIPT_KEY }}" >> .env.production

--- a/my-web-builder/apps/frontend/src/config.js
+++ b/my-web-builder/apps/frontend/src/config.js
@@ -67,7 +67,7 @@ export const API_BASE_URL = getEnvVar('VITE_API_URL') || getEnvVar('NEXT_PUBLIC_
 
 // Y.js WebSocket 서버 설정 - 환경변수 기반
 export const YJS_WEBSOCKET_URL = getEnvVar('VITE_YJS_WEBSOCKET_URL') || getEnvVar('VITE_WEBSOCKET_URL') || getEnvVar('NEXT_PUBLIC_YJS_WEBSOCKET_URL') ||
-  (isProductionEnvironment() ? 'wss://pagecube.net/yjs' : `ws://${getLocalNetworkIP()}:1234`);
+  (isProductionEnvironment() ? 'wss://3.35.50.227:1235' : `ws://${getLocalNetworkIP()}:1234`);
 
 // 소셜 로그인 설정
 export const GOOGLE_CLIENT_ID = getEnvVar('VITE_GOOGLE_CLIENT_ID') || getEnvVar('NEXT_PUBLIC_GOOGLE_CLIENT_ID') || '';


### PR DESCRIPTION
✅ SSL 지원 추가:
- HTTP WebSocket: ws://3.35.50.227:1234
- HTTPS WebSocket: wss://3.35.50.227:1235 (자체 서명 인증서)

🔧 설정 업데이트:
- GitHub Actions: WSS 포트 1235 사용
- config.js: 프로덕션 환경에서 WSS 연결
- 자체 서명 인증서로 HTTPS 환경 지원

⚠️ 주의사항:
- 브라우저에서 자체 서명 인증서 보안 경고 발생 가능
- 사용자가 인증서를 수동으로 승인해야 할 수 있음

## 📋 PR 요약

<!-- 작업 내용 한 줄로 요약 -->

## 📋 Issue 번호

- close # 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

## 📎 스크린샷
