### PR TITLE
🔧 임시로 HTTP WebSocket 사용 (Mixed Content 이슈 해결)

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           cd my-web-builder/apps/frontend
           echo "VITE_API_URL=https://pagecube.net/api" > .env.production
-          echo "VITE_YJS_WEBSOCKET_URL=wss://3.35.50.227:1235" >> .env.production
+          echo "VITE_YJS_WEBSOCKET_URL=ws://3.35.50.227:1234" >> .env.production
           echo "VITE_SUBDOMAIN_URL=http://3.35.141.231:3001" >> .env.production
           echo "VITE_GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env.production
           echo "VITE_KAKAO_CLIENT_ID=${{ secrets.KAKAO_JAVASCRIPT_KEY }}" >> .env.production

--- a/my-web-builder/apps/frontend/src/config.js
+++ b/my-web-builder/apps/frontend/src/config.js
@@ -67,7 +67,7 @@ export const API_BASE_URL = getEnvVar('VITE_API_URL') || getEnvVar('NEXT_PUBLIC_
 
 // Y.js WebSocket 서버 설정 - 환경변수 기반
 export const YJS_WEBSOCKET_URL = getEnvVar('VITE_YJS_WEBSOCKET_URL') || getEnvVar('VITE_WEBSOCKET_URL') || getEnvVar('NEXT_PUBLIC_YJS_WEBSOCKET_URL') ||
-  (isProductionEnvironment() ? 'wss://3.35.50.227:1235' : `ws://${getLocalNetworkIP()}:1234`);
+  (isProductionEnvironment() ? 'ws://3.35.50.227:1234' : `ws://${getLocalNetworkIP()}:1234`);
 
 // 소셜 로그인 설정
 export const GOOGLE_CLIENT_ID = getEnvVar('VITE_GOOGLE_CLIENT_ID') || getEnvVar('NEXT_PUBLIC_GOOGLE_CLIENT_ID') || '';


### PR DESCRIPTION
⚠️ 임시 해결책:
- WSS 자체 서명 인증서 브라우저 보안 정책 문제로 인해
- 임시로 HTTP WebSocket(ws://) 사용
- 프로덕션: ws://3.35.50.227:1234

🔒 보안 고려사항:
- HTTPS 페이지에서 WS 연결 시 Mixed Content 경고 발생 가능
- 브라우저에서 안전하지 않은 콘텐츠 허용 필요할 수 있음
- 향후 정식 SSL 인증서 적용 권장

✅ 서버 상태:
- HTTP WebSocket: 포트 1234 ✅ 정상 작동
- HTTPS WebSocket: 포트 1235 ✅ 대기 중

## 📋 PR 요약

<!-- 작업 내용 한 줄로 요약 -->

## 📋 Issue 번호

- close # 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

## 📎 스크린샷
