### PR TITLE
🔧 HTTP WebSocket 사용으로 자체 서명 인증서 문제 우회

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -33,7 +33,7 @@ jobs:
           cd my-web-builder/apps/frontend
           rm -f .env.production
           echo "VITE_API_URL=https://pagecube.net/api" > .env.production
-          echo "VITE_YJS_WEBSOCKET_URL=wss://3.35.50.227:1235" >> .env.production
+          echo "VITE_YJS_WEBSOCKET_URL=ws://3.35.50.227:1234" >> .env.production
           echo "VITE_SUBDOMAIN_URL=http://3.35.141.231:3001" >> .env.production
           echo "VITE_GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env.production
           echo "VITE_KAKAO_CLIENT_ID=${{ secrets.KAKAO_JAVASCRIPT_KEY }}" >> .env.production

--- a/my-web-builder/apps/frontend/src/config.js
+++ b/my-web-builder/apps/frontend/src/config.js
@@ -67,7 +67,7 @@ export const API_BASE_URL = getEnvVar('VITE_API_URL') || getEnvVar('NEXT_PUBLIC_
 
 // Y.js WebSocket 서버 설정 - 환경변수 기반
 export const YJS_WEBSOCKET_URL = getEnvVar('VITE_YJS_WEBSOCKET_URL') || getEnvVar('VITE_WEBSOCKET_URL') || getEnvVar('NEXT_PUBLIC_YJS_WEBSOCKET_URL') ||
-  (isProductionEnvironment() ? 'wss://3.35.50.227:1235' : `ws://${getLocalNetworkIP()}:1234`);
+  (isProductionEnvironment() ? 'ws://3.35.50.227:1234' : `ws://${getLocalNetworkIP()}:1234`);
 
 // 소셜 로그인 설정
 export const GOOGLE_CLIENT_ID = getEnvVar('VITE_GOOGLE_CLIENT_ID') || getEnvVar('NEXT_PUBLIC_GOOGLE_CLIENT_ID') || '';


### PR DESCRIPTION
🚨 문제:
- WSS 자체 서명 인증서로 인한 브라우저 연결 차단
- 협업 기능 연결 실패로 컴포넌트 동작 불가

🔧 해결책:
- HTTP WebSocket 사용: ws://3.35.50.227:1234
- Mixed Content 경고 발생하지만 연결 가능
- 브라우저에서 안전하지 않은 콘텐츠 허용 필요

⚠️ 사용자 액션:
1. Chrome: 주소창 자물쇠 → 사이트 설정 → 안전하지 않은 콘텐츠 허용
2. Firefox: 방패 아이콘 → 보호 기능 해제
3. 페이지 새로고침

🎯 목표: 협업 기능 연결 성공으로 컴포넌트 정상 작동

## 📋 PR 요약

<!-- 작업 내용 한 줄로 요약 -->

## 📋 Issue 번호

- close # 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

## 📎 스크린샷
