### PR TITLE
🔒 WSS + 사용자 안내 UI로 WebSocket 연결 문제 해결

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -33,7 +33,7 @@ jobs:
           cd my-web-builder/apps/frontend
           rm -f .env.production
           echo "VITE_API_URL=https://pagecube.net/api" > .env.production
-          echo "VITE_YJS_WEBSOCKET_URL=ws://3.35.50.227:1234" >> .env.production
+          echo "VITE_YJS_WEBSOCKET_URL=wss://3.35.50.227:1235" >> .env.production
           echo "VITE_SUBDOMAIN_URL=http://3.35.141.231:3001" >> .env.production
           echo "VITE_GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env.production
           echo "VITE_KAKAO_CLIENT_ID=${{ secrets.KAKAO_JAVASCRIPT_KEY }}" >> .env.production

--- a/my-web-builder/apps/frontend/src/components/WebSocketConnectionGuide.jsx
+++ b/my-web-builder/apps/frontend/src/components/WebSocketConnectionGuide.jsx
@@ -1,0 +1,84 @@
+import React, { useState } from 'react';
+
+const WebSocketConnectionGuide = ({ wsUrl, onRetry }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleCertificateSetup = () => {
+    // 새 탭에서 HTTPS 서버 열기
+    window.open(wsUrl.replace('wss://', 'https://'), '_blank');
+  };
+
+  return (
+    <div className="fixed top-4 right-4 max-w-md bg-yellow-50 border border-yellow-200 rounded-lg shadow-lg z-50">
+      <div className="p-4">
+        <div className="flex items-start">
+          <div className="flex-shrink-0">
+            <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+            </svg>
+          </div>
+          <div className="ml-3 flex-1">
+            <h3 className="text-sm font-medium text-yellow-800">
+              협업 기능 연결 필요
+            </h3>
+            <div className="mt-2 text-sm text-yellow-700">
+              <p>실시간 협업을 위해 보안 인증서 승인이 필요합니다.</p>
+            </div>
+            <div className="mt-3 flex space-x-2">
+              <button
+                onClick={handleCertificateSetup}
+                className="bg-yellow-100 hover:bg-yellow-200 text-yellow-800 text-xs font-medium px-3 py-1 rounded border border-yellow-300 transition-colors"
+              >
+                인증서 승인하기
+              </button>
+              <button
+                onClick={onRetry}
+                className="bg-blue-100 hover:bg-blue-200 text-blue-800 text-xs font-medium px-3 py-1 rounded border border-blue-300 transition-colors"
+              >
+                다시 연결
+              </button>
+              <button
+                onClick={() => setIsExpanded(!isExpanded)}
+                className="text-yellow-600 hover:text-yellow-800 text-xs font-medium px-2 py-1 transition-colors"
+              >
+                {isExpanded ? '접기' : '자세히'}
+              </button>
+            </div>
+          </div>
+          <div className="ml-auto pl-3">
+            <div className="-mx-1.5 -my-1.5">
+              <button
+                onClick={() => document.querySelector('.websocket-guide').style.display = 'none'}
+                className="inline-flex bg-yellow-50 rounded-md p-1.5 text-yellow-500 hover:bg-yellow-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-yellow-50 focus:ring-yellow-600"
+              >
+                <span className="sr-only">닫기</span>
+                <svg className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
+                </svg>
+              </button>
+            </div>
+          </div>
+        </div>
+        
+        {isExpanded && (
+          <div className="mt-4 text-sm text-yellow-700 border-t border-yellow-200 pt-4">
+            <h4 className="font-medium mb-2">📋 인증서 승인 방법:</h4>
+            <ol className="list-decimal list-inside space-y-1 text-xs">
+              <li>"인증서 승인하기" 버튼 클릭</li>
+              <li>새 탭에서 보안 경고 화면이 나타남</li>
+              <li>"고급" 또는 "Advanced" 클릭</li>
+              <li>"안전하지 않음으로 이동" 또는 "Proceed to..." 클릭</li>
+              <li>"Y.js WebSocket Server (HTTPS) is running!" 메시지 확인</li>
+              <li>이 페이지로 돌아와서 "다시 연결" 클릭</li>
+            </ol>
+            <div className="mt-3 p-2 bg-yellow-100 rounded text-xs">
+              <strong>💡 팁:</strong> 인증서는 한 번만 승인하면 됩니다. 이후 자동으로 연결됩니다.
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default WebSocketConnectionGuide;

--- a/my-web-builder/apps/frontend/src/config.js
+++ b/my-web-builder/apps/frontend/src/config.js
@@ -67,7 +67,7 @@ export const API_BASE_URL = getEnvVar('VITE_API_URL') || getEnvVar('NEXT_PUBLIC_
 
 // Y.js WebSocket 서버 설정 - 환경변수 기반
 export const YJS_WEBSOCKET_URL = getEnvVar('VITE_YJS_WEBSOCKET_URL') || getEnvVar('VITE_WEBSOCKET_URL') || getEnvVar('NEXT_PUBLIC_YJS_WEBSOCKET_URL') ||
-  (isProductionEnvironment() ? 'ws://3.35.50.227:1234' : `ws://${getLocalNetworkIP()}:1234`);
+  (isProductionEnvironment() ? 'wss://3.35.50.227:1235' : `ws://${getLocalNetworkIP()}:1234`);
 
 // 소셜 로그인 설정
 export const GOOGLE_CLIENT_ID = getEnvVar('VITE_GOOGLE_CLIENT_ID') || getEnvVar('NEXT_PUBLIC_GOOGLE_CLIENT_ID') || '';

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor.jsx
@@ -13,6 +13,7 @@ import TemplateModal from './NoCodeEditor/components/TemplateModal';
 import InviteModal from './NoCodeEditor/components/InviteModal';
 import CanvasComponent from './NoCodeEditor/components/CanvasComponent';
 import UserCursor from './NoCodeEditor/components/UserCursor';
+import WebSocketConnectionGuide from '../components/WebSocketConnectionGuide';
 
 // 훅들
 import { usePageDataManager } from '../hooks/usePageDataManager';
@@ -498,6 +499,21 @@ function NoCodeEditor({ pageId }) {
         onClose={interaction.handleInviteClose}
         pageId={pageId}
       />
+
+      {/* WebSocket 연결 안내 UI */}
+      {connectionError && (
+        <div className="websocket-guide">
+          <WebSocketConnectionGuide
+            wsUrl="wss://3.35.50.227:1235"
+            onRetry={() => {
+              // 협업 시스템 재연결 시도
+              if (collaboration.provider) {
+                collaboration.provider.connect();
+              }
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
🚨 Mixed Content 정책으로 WS 연결 완전 차단:
- HTTPS 페이지에서 WS 연결은 브라우저 수준에서 차단
- 사용자 설정으로도 우회 불가능

✅ 확실한 해결책 적용:
- WSS 사용: wss://3.35.50.227:1235
- 사용자 안내 UI 추가: WebSocketConnectionGuide 컴포넌트
- 인증서 승인 가이드 제공

🎯 사용자 경험 개선:
- 연결 실패 시 친화적인 안내 메시지
- 원클릭 인증서 승인 링크
- 단계별 상세 가이드 제공
- 재연결 버튼으로 즉시 재시도 가능

📋 사용법:
1. 페이지 로드 시 연결 실패 알림 표시
2. '인증서 승인하기' 버튼으로 새 탭에서 HTTPS 서버 접속
3. 브라우저 보안 경고에서 인증서 승인
4. '다시 연결' 버튼으로 WebSocket 재연결

## 📋 PR 요약

<!-- 작업 내용 한 줄로 요약 -->

## 📋 Issue 번호

- close # 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

## 📎 스크린샷
