### PR TITLE
Fix: Make getMyPagesForNavigation return array instead of object

### DIFF
--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -108,21 +108,10 @@ export class UsersService {
     );
   }
 
-  // 네비게이션용 내 페이지 목록 조회 (간소화된 정보)
-  async getMyPagesForNavigation(userId: number, currentPageId?: string): Promise<any> {
-    const pages = await this.getMyPages(userId);
-    
-    return {
-      pages: pages.map(page => ({
-        id: page.id,
-        title: page.title,
-        subdomain: page.subdomain,
-        status: page.status,
-        updatedAt: page.updatedAt,
-        isCurrent: page.id === currentPageId
-      })),
-      total: pages.length
-    };
+  // 네비게이션용 내 페이지 목록 조회 (기존 getMyPages와 동일)
+  async getMyPagesForNavigation(userId: number, currentPageId?: string): Promise<Pages[]> {
+    // 기존 getMyPages 메서드와 동일하게 배열 반환
+    return this.getMyPages(userId);
   }
 
   // 페이지 단일 조회


### PR DESCRIPTION
- Change return type to Pages[] to match frontend expectations
- Fix TypeError: filter/find is not a function errors in canvas page
- Maintain compatibility with existing frontend code

## 📋 PR 요약

<!-- 작업 내용 한 줄로 요약 -->

## 📋 Issue 번호

- close # 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

## 📎 스크린샷
