### PR TITLE
웨딩 템플릿 편집기준 모바일로만 고정

### DIFF
--- a/my-web-builder/apps/frontend/src/hooks/useEditorInteractionManager.js
+++ b/my-web-builder/apps/frontend/src/hooks/useEditorInteractionManager.js
@@ -6,12 +6,12 @@ import { API_BASE_URL } from '../config.js';
  * - UI 상태 관리 (선택, 줌, 패널, 모달 등)
  * - 뷰포트/편집모드 전환 핸들러
  */
-export function useEditorInteractionManager(designMode, setDesignMode) {
+export function useEditorInteractionManager(designMode, setDesignMode, initialViewport = null) {
   // UI 상태 관리
   const [selectedId, setSelectedId] = useState(null);
   const [snapLines, setSnapLines] = useState({ vertical: [], horizontal: [] });
   const [zoom, setZoom] = useState(100); // 줌 초기값을 60%로 설정
-  const [viewport, setViewport] = useState(designMode);
+  const [viewport, setViewport] = useState(initialViewport || designMode);
   const [isLibraryOpen, setIsLibraryOpen] = useState(true);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
 

--- a/my-web-builder/apps/frontend/src/pages/DashboardPage.jsx
+++ b/my-web-builder/apps/frontend/src/pages/DashboardPage.jsx
@@ -147,12 +147,20 @@ function DashboardPage({ user, onLogout }) {
 
       if (response.ok) {
         const newPage = await response.json();
-        navigate(`/editor/${newPage.id}`);
+        // 템플릿 정보 찾기
+        const template = templates.find(t => t.id === templateId);
+        
+        // 템플릿 정보를 URL 파라미터로 전달
+        const templateParam = template ? encodeURIComponent(JSON.stringify(template)) : null;
+        const editorUrl = templateParam 
+          ? `/editor/${newPage.id}?template=${templateParam}`
+          : `/editor/${newPage.id}`;
+        
+        navigate(editorUrl);
       } else {
         alert('템플릿 페이지 생성에 실패했습니다.');
       }
     } catch (error) {
-      console.error('템플릿 페이지 생성 실패:', error);
       alert('템플릿 페이지 생성에 실패했습니다.');
     }
   };

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/components/EditorHeader.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/components/EditorHeader.jsx
@@ -22,6 +22,7 @@ function EditorHeader({
   isConnected,
   connectionError,
   isAdmin,
+  templateCategory = null,
 }) {
   const navigate = useNavigate();
 
@@ -101,7 +102,7 @@ n          {/* 페이지 네비게이션 */}
                 cursor-pointer
               "
             >
-              <option value="desktop">💻 데스크탑</option>
+              {templateCategory !== 'wedding' && <option value="desktop">💻 데스크탑</option>}
               <option value="mobile">📱 모바일</option>
             </select>
           </div>


### PR DESCRIPTION
## 📋 PR 요약

<!-- 작업 내용 한 줄로 요약 -->

## 📢 공유하고 싶은 내용

1. DashboardPage:
```
// wedding 템플릿 정보를 URL에 포함
navigate(`/editor/${newPage.id}?template=${templateParam}`);
```
2. NoCodeEditor:
```
// URL에서 카테고리 추출
templateCategory = 'wedding'
```
3. usePageDataManager: designMode = 'desktop'

4. EditorHeader:
```
// wedding이므로 데스크톱 옵션 숨김
{templateCategory !== 'wedding' && <option value="desktop">💻 데스크톱</option>} // 숨겨짐
<option value="mobile">📱 모바일</option> // 이것만 표시
```

## 📎 스크린샷
<img width="1920" height="1580" alt="image" src="https://github.com/user-attachments/assets/7b4adc3b-3a3a-40fa-81d1-388076da4e7a" />
