### PR TITLE
안내장 컴포넌트 렌더링 관련 수정

### DIFF
--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/WeddingInviteEditor.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/WeddingInviteEditor.jsx
@@ -12,7 +12,7 @@ function WeddingInviteEditor({ selectedComp, onUpdate }) {
   const {
     title = "Our Love Story",
     titleFontFamily = "\"Dancing Script\", \"cursive\", \"Noto Sans KR\", \"맑은 고딕\", sans-serif",
-    titleFontSize = 32,
+    titleFontSize = 30,
     titleFontStyle = "italic",
     titleFontWeight = "normal",
     titleTextDecoration = "none",
@@ -28,7 +28,7 @@ function WeddingInviteEditor({ selectedComp, onUpdate }) {
       "축복해 주시면 감사하겠습니다."
     ],
     contentFontFamily = "\"Noto Sans KR\", \"맑은 고딕\", sans-serif",
-    contentFontSize = 26,
+    contentFontSize = 18,
     contentFontWeight = "normal",
     contentFontStyle = "normal",
     contentTextDecoration = "none",

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/WeddingInviteRenderer.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/WeddingInviteRenderer.jsx
@@ -6,7 +6,7 @@ export default function WeddingInviteRenderer({ comp }) {
         containerHeight = comp.height || 400,
         title = "Our Love Story",
         titleFontFamily = "Playfair Display, serif",
-        titleFontSize = 36,
+        titleFontSize = 30,
         titleFontStyle = "italic",
         titleFontWeight = "600",
         titleTextDecoration = "none",
@@ -42,7 +42,7 @@ export default function WeddingInviteRenderer({ comp }) {
             style={{
                 padding: 40,
                 background: backgroundColor,
-                borderRadius: 16,
+                borderRadius: 0,
                 width: '100%',
                 height: '100%',
                 minWidth: 200,

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/utils/editorUtils.js
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/utils/editorUtils.js
@@ -6,7 +6,7 @@ export function getComponentDimensions(type) {
     button: { defaultWidth: 150, defaultHeight: 50, minWidth: 100, minHeight: 50 },
     text: { defaultWidth: 200, defaultHeight: 50, minWidth: 100, minHeight: 50 },
     image: { defaultWidth: 200, defaultHeight: 150, minWidth: 100, minHeight: 100 },
-    map: { defaultWidth: 350, defaultHeight: 240, minWidth: 200, minHeight: 150 },
+    map: { defaultWidth: 350, defaultHeight: 250, minWidth: 200, minHeight: 150 },
     link: { defaultWidth: 150, defaultHeight: 50, minWidth: 100, minHeight: 50 },
     attend: { defaultWidth: 300, defaultHeight: 200, minWidth: 250, minHeight: 150 },
     dday: { defaultWidth: 350, defaultHeight: 150, minWidth: 150, minHeight: 100 },

--- a/my-web-builder/apps/frontend/src/pages/components/definitions/wedding-invite.json
+++ b/my-web-builder/apps/frontend/src/pages/components/definitions/wedding-invite.json
@@ -4,7 +4,7 @@
   "defaultProps": {
     "title": "Our Love Story",
     "titleFontFamily": "\"Dancing Script\", \"cursive\", \"Noto Sans KR\", \"맑은 고딕\", sans-serif",
-    "titleFontSize": 32,
+    "titleFontSize": 30,
     "titleFontStyle": "italic",
     "titleColor": "#aaa",
     "content": [
@@ -17,7 +17,7 @@
       "축복해 주시면 감사하겠습니다."
     ],
     "contentFontFamily": "\"Noto Sans KR\", \"맑은 고딕\", sans-serif",
-    "contentFontSize": 26,
+    "contentFontSize": 18,
     "contentFontWeight": "normal",
     "contentColor": "#444",
     "textAlign": "center",


### PR DESCRIPTION
## 📋 PR 요약

안내장 컴포넌트 렌더링 관련 수정

## 📋 Issue 번호

- close #300 

## 🔍 변경 사항

- 변경 1: 안내장 컴포넌트 수정
- 변경 2: 지도 defaultHeight 240이었던거 250으로 수정

## 📢 공유하고 싶은 내용

렌더링된 컴포넌트의 사이즈는 유지하고, 그 안에 있는 텍스트 크기를 조절해서 렌더링될때 스크롤이 안생기게함
기존에 지적했던 모서리 둥글기도 수정함


## 📎 스크린샷

<img width="544" height="544" alt="스크린샷 2025-07-11 234201" src="https://github.com/user-attachments/assets/34729808-1005-422d-b07b-7abd6d5101fd" />
<img width="303" height="322" alt="스크린샷 2025-07-12 000550" src="https://github.com/user-attachments/assets/a6806996-3dc5-443c-bbd0-feca4a2e9506" />
<img width="301" height="345" alt="스크린샷 2025-07-12 000743" src="https://github.com/user-attachments/assets/78f13edd-276a-4899-9a73-37285a7f8fe1" />


