### PR TITLE
이미지 컴포넌트 모서리 둥글기 수정

### DIFF
--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/ImageRenderer.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/ImageRenderer.jsx
@@ -10,6 +10,8 @@ function ImageRenderer({ comp, component, isEditor = false, isPreview = false, o
   const animationRef = useRef(null);
   const [particles, setParticles] = useState([]);
   const animationFrameRef = useRef(null);
+
+  const borderRadius = actualComp?.props?.borderRadius ?? 0; 
   
   // 동적 애니메이션 효과 초기화
   useEffect(() => {
@@ -162,7 +164,7 @@ function ImageRenderer({ comp, component, isEditor = false, isPreview = false, o
   const containerStyle = {
     width: '100%',
     height: '100%',
-    borderRadius: '0px',
+    borderRadius: `${borderRadius}px`,
     overflow: 'hidden',
     position: 'relative',
     display: 'flex',
@@ -252,7 +254,8 @@ function ImageRenderer({ comp, component, isEditor = false, isPreview = false, o
           height: '100%',
           objectFit: actualComp?.props?.objectFit || 'cover',
           display: imageError ? 'none' : 'block',
-          transition: 'all 0.3s ease'
+          transition: 'all 0.3s ease',
+          borderRadius: `${borderRadius}px`
         }}
       />
       

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/components/CanvasComponent.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/components/CanvasComponent.jsx
@@ -203,6 +203,16 @@ function CanvasComponent({
             onUpdate={onUpdate}
           />
         );
+
+      case 'text':
+        return (
+          <TextRenderer
+            component={componentWithFinalStyles}
+            isEditor={true}
+            onUpdate={onUpdate}
+          />
+        );
+
       case 'link':
         return (
           <LinkRenderer


### PR DESCRIPTION
## 📋 PR 요약

이미지 컴포넌트 모서리 둥글기 수정

## 📋 Issue 번호

- close #339 

## 🔍 변경 사항

- 변경 : ImageRenderer.jsx

## 📢 공유하고 싶은 내용

ImageRenderer.jsx에서 
borderRadius: `0px`를 borderRadius: `${borderRadius}px`으로 수정하고 
상단에 const borderRadius = actualComp?.props?.borderRadius ?? 0;를 추가하여 해결함

CSS에서 ${borderRadius}px``로 써야 단위(px)가 붙어서 스타일이 적용됨.
0px로 고정하면 안됐음 -> 에디터에서 값을 조절해도 렌더러에서 그 값을 반영하지 않음

## 📎 스크린샷
<img width="232" height="183" alt="스크린샷 2025-07-12 213503" src="https://github.com/user-attachments/assets/579c74bd-ccda-417f-a7b0-ef0697ab6188" />
<img width="232" height="183" alt="스크린샷 2025-07-12 213503" src="https://github.com/user-attachments/assets/689e36c7-4111-4ec3-8135-74d63ddb8d4c" />
<img width="239" height="178" alt="스크린샷 2025-07-12 213515" src="https://github.com/user-attachments/assets/fd108f9d-e06a-4080-a2da-499635bbfc5c" />
<img width="225" height="161" alt="스크린샷 2025-07-12 213521" src="https://github.com/user-attachments/assets/91668289-06d6-4b49-8533-b555c8f9af7d" />


