### PR TITLE
페이지 컴포넌트 테두리 제거 추가

### DIFF
--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/PageEditor.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/PageEditor.jsx
@@ -11,23 +11,34 @@ import {
 
 const PageEditor = ({ selectedComp, onUpdate }) => {
   const [localProps, setLocalProps] = useState(selectedComp.props || {});
+  const [noBorder, setNoBorder] = useState(
+    selectedComp.props?.noBorder !== undefined ? !!selectedComp.props.noBorder : true
+  );
 
   // 컴포넌트 props 초기화
   useEffect(() => {
     if (selectedComp && selectedComp.props) {
       setLocalProps(selectedComp.props);
+      setNoBorder(selectedComp.props.noBorder !== undefined ? !!selectedComp.props.noBorder : true);
     }
   }, [selectedComp]);
 
   const updateProperty = (key, value) => {
     const newProps = { ...localProps, [key]: value };
     setLocalProps(newProps);
-    
+    if (key === 'noBorder') setNoBorder(!!value);
     const updatedComponent = {
       ...selectedComp,
       props: newProps
     };
     onUpdate(updatedComponent);
+  };
+
+  // 테두리 제거 체크박스 핸들러
+  const handleNoBorderChange = (e) => {
+    const checked = e.target.checked;
+    setNoBorder(checked);
+    updateProperty('noBorder', checked);
   };
 
   const handleThumbnailUpload = async (file) => {
@@ -156,29 +167,47 @@ const PageEditor = ({ selectedComp, onUpdate }) => {
         key: 'style-title',
         style: { marginBottom: '12px', color: '#495057' }
       }, '스타일 설정'),
-      
+
+      // 테두리 제거 체크박스
+      React.createElement('div', {
+        key: 'no-border-checkbox',
+        style: { marginBottom: '12px' }
+      }, [
+        React.createElement('label', { key: 'label', style: { display: 'flex', alignItems: 'center', gap: '8px', fontSize: '14px' } }, [
+          React.createElement('input', {
+            key: 'checkbox',
+            type: 'checkbox',
+            checked: noBorder,
+            onChange: handleNoBorderChange,
+            style: { accentColor: '#007bff' }
+          }),
+          '테두리 제거'
+        ])
+      ]),
+
       React.createElement(ColorEditor, {
         key: 'backgroundColor',
         value: localProps.backgroundColor || '#ffffff',
         onChange: (value) => updateProperty('backgroundColor', value),
         label: '배경색'
       }),
-      
+
       React.createElement(ColorEditor, {
         key: 'textColor',
         value: localProps.textColor || '#333333',
         onChange: (value) => updateProperty('textColor', value),
         label: '텍스트 색상'
       }),
-      
-      React.createElement(ColorEditor, {
+
+      // 테두리 관련 에디터는 noBorder가 false일 때만 표시
+      !noBorder && React.createElement(ColorEditor, {
         key: 'borderColor',
         value: localProps.borderColor || '#007bff',
         onChange: (value) => updateProperty('borderColor', value),
         label: '테두리 색상'
       }),
-      
-      React.createElement(SelectEditor, {
+
+      !noBorder && React.createElement(SelectEditor, {
         key: 'borderWidth',
         value: localProps.borderWidth || '2px',
         onChange: (value) => updateProperty('borderWidth', value),
@@ -190,8 +219,8 @@ const PageEditor = ({ selectedComp, onUpdate }) => {
           { value: '4px', label: '4px' }
         ]
       }),
-      
-      React.createElement(NumberEditor, {
+
+      !noBorder && React.createElement(NumberEditor, {
         key: 'borderRadius',
         value: parseInt(localProps.borderRadius) || 8,
         onChange: (value) => updateProperty('borderRadius', value),
@@ -200,7 +229,7 @@ const PageEditor = ({ selectedComp, onUpdate }) => {
         max: 50,
         suffix: 'px'
       }),
-      
+
       React.createElement(NumberEditor, {
         key: 'fontSize',
         value: parseInt(localProps.fontSize) || 14,
@@ -210,7 +239,7 @@ const PageEditor = ({ selectedComp, onUpdate }) => {
         max: 32,
         suffix: 'px'
       }),
-      
+
       React.createElement(SelectEditor, {
         key: 'fontWeight',
         value: localProps.fontWeight || '500',

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/PageRenderer.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/PageRenderer.jsx
@@ -16,7 +16,8 @@ const PageRenderer = ({ component, comp, mode = 'editor', onUpdate }) => {
     fontSize = 14,
     fontWeight = '500',
     linkedPageId = '',
-    deployedUrl = ''
+    deployedUrl = '',
+    noBorder = true
   } = actualComp?.props || {};
 
   const handleClick = (e) => {
@@ -75,7 +76,8 @@ const PageRenderer = ({ component, comp, mode = 'editor', onUpdate }) => {
       width: '100%',
       height: '100%',
       backgroundColor,
-      border: `${borderWidth} solid ${borderColor}`,
+      //border: `${borderWidth} solid ${borderColor}`,
+      border: noBorder ? 'none' : `${borderWidth} solid ${borderColor}`,
       borderRadius: 0,
       cursor: 'pointer',
       display: 'flex',

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/utils/editorUtils.js
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/utils/editorUtils.js
@@ -8,7 +8,7 @@ export function getComponentDimensions(type) {
     image: { defaultWidth: 200, defaultHeight: 150, minWidth: 100, minHeight: 100 },
     map: { defaultWidth: 375, defaultHeight: 250, minWidth: 200, minHeight: 150 },
     link: { defaultWidth: 150, defaultHeight: 50, minWidth: 100, minHeight: 50 },
-    attend: { defaultWidth: 375, defaultHeight: 200, minWidth: 250, minHeight: 150 },
+    attend: { defaultWidth: 375, defaultHeight: 300, minWidth: 250, minHeight: 150 },
     dday: { defaultWidth: 375, defaultHeight: 200, minWidth: 150, minHeight: 100 },
     weddingContact: { defaultWidth: 375, defaultHeight: 250, minWidth: 250, minHeight: 200 },
     weddingInvite: { defaultWidth: 375, defaultHeight: 400, minWidth: 300, minHeight: 250 },

--- a/my-web-builder/apps/frontend/src/pages/components/definitions/page.json
+++ b/my-web-builder/apps/frontend/src/pages/components/definitions/page.json
@@ -69,6 +69,11 @@
       "options": ["400", "500", "600", "700"],
       "default": "500"
     },
+    "noBorder": {
+      "type": "boolean",
+      "label": "테두리 제거",
+      "default": true
+    },
     "linkedPageId": {
       "type": "hidden",
       "default": ""
@@ -96,7 +101,8 @@
     "fontWeight": "500",
     "linkedPageId": "",
     "deployedUrl": "",
-    "autoCreated": false
+    "autoCreated": false,
+    "noBorder": true
   },
   "dimensions": {
     "width": 200,

--- a/my-web-builder/apps/subdomain-nextjs/next-env.d.ts
+++ b/my-web-builder/apps/subdomain-nextjs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## 📋 PR 요약

페이지 컴포넌트에 "테두리 제거" 추가

## 📋 Issue 번호

- close #365 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

번외로, 참석여부 컴포넌트 높이도 200에서 300으로 증가시킴

## 📎 스크린샷
<img width="228" height="102" alt="스크린샷 2025-07-14 191824" src="https://github.com/user-attachments/assets/95465a3a-5993-41ea-939d-e4c8ee28213c" />
<img width="683" height="350" alt="스크린샷 2025-07-14 191828" src="https://github.com/user-attachments/assets/50aa99ed-01cf-4241-92e6-244032d621d2" />
<img width="667" height="458" alt="스크린샷 2025-07-14 191833" src="https://github.com/user-attachments/assets/df6dcd1d-684a-4143-8547-d0cd2a33ecc8" />


