### PR TITLE
지도안내 컴포넌트 테두리 제거 추가

### DIFF
--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/MapInfoEditor.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/MapInfoEditor.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   TextEditor,
   NumberEditor,
   FontFamilyEditor,
   TextStyleEditor,
-  ColorEditor
+  ColorEditor,
+  SelectEditor
 } from '../PropertyEditors';
 
 function MapInfoEditor({ selectedComp, onUpdate }) {
@@ -17,7 +18,17 @@ function MapInfoEditor({ selectedComp, onUpdate }) {
     color = '#222',
     bgColor = '#fff',
     sections = [],
+    noBorder = true,
+    borderColor = '#e5e7eb',
+    borderWidth = '1px',
+    borderRadius = 8,
   } = selectedComp.props;
+
+  const [localNoBorder, setLocalNoBorder] = useState(noBorder);
+
+  useEffect(() => {
+    setLocalNoBorder(selectedComp.props?.noBorder !== undefined ? !!selectedComp.props.noBorder : true);
+  }, [selectedComp.props?.noBorder]);
 
   // 공통 스타일 업데이트
   const updateCommon = (key, value) => {
@@ -28,6 +39,12 @@ function MapInfoEditor({ selectedComp, onUpdate }) {
         [key]: value
       }
     });
+  };
+
+  // 테두리 제거 체크박스 핸들러
+  const handleNoBorderChange = (e) => {
+    setLocalNoBorder(e.target.checked);
+    updateCommon('noBorder', e.target.checked);
   };
 
   // 섹션 내용 업데이트
@@ -51,8 +68,6 @@ function MapInfoEditor({ selectedComp, onUpdate }) {
 
   return (
     <div>
-
-
       {/* 공통 스타일 */}
       <div style={{ fontSize: 12, color: '#65676b', fontWeight: 600, marginBottom: 12 }}>
         공통 스타일
@@ -90,6 +105,46 @@ function MapInfoEditor({ selectedComp, onUpdate }) {
         onChange={v => updateCommon('bgColor', v)}
         label="배경색"
       />
+
+      {/* 테두리 옵션 */}
+      <div style={{ margin: '16px 0 8px 0', display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input
+          type="checkbox"
+          checked={localNoBorder}
+          onChange={handleNoBorderChange}
+          id="noBorderCheckbox"
+          style={{ accentColor: '#007bff' }}
+        />
+        <label htmlFor="noBorderCheckbox" style={{ fontSize: 14 }}>테두리 제거</label>
+      </div>
+      {!localNoBorder && (
+        <>
+          <ColorEditor
+            value={borderColor}
+            onChange={v => updateCommon('borderColor', v)}
+            label="테두리 색상"
+          />
+          <SelectEditor
+            value={borderWidth}
+            onChange={v => updateCommon('borderWidth', v)}
+            label="테두리 두께"
+            options={[
+              { value: '1px', label: '1px' },
+              { value: '2px', label: '2px' },
+              { value: '3px', label: '3px' },
+              { value: '4px', label: '4px' }
+            ]}
+          />
+          <NumberEditor
+            value={parseInt(borderRadius) || 8}
+            onChange={v => updateCommon('borderRadius', v)}
+            label="모서리 둥글기"
+            min={0}
+            max={50}
+            suffix="px"
+          />
+        </>
+      )}
 
       <div style={{ height: 1, backgroundColor: '#eee', margin: '16px 0' }} />
 

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/MapInfoRenderer.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/MapInfoRenderer.jsx
@@ -14,7 +14,11 @@ export default function MapInfoRenderer({ comp, mode = 'editor' }) {
     lineHeight = comp.props?.lineHeight || 1.6,
     letterSpacing = comp.props?.letterSpacing || 0,
     color = comp.props?.color || '#2c2c2c',
-    bgColor = comp.props?.bgColor || '#ffffff'
+    bgColor = comp.props?.bgColor || '#ffffff',
+    noBorder = true,
+    borderColor = comp.props?.borderColor || '#e5e7eb',
+    borderWidth = comp.props?.borderWidth || '1px',
+    borderRadius = comp.props?.borderRadius || 8
   } = comp.props;
 
   const toPx = v => (typeof v === 'number' ? `${v}px` : v || undefined);
@@ -24,14 +28,14 @@ export default function MapInfoRenderer({ comp, mode = 'editor' }) {
     <div
       style={{
         padding: '28px 24px',
-        background: `linear-gradient(135deg, ${bgColor} 0%, #f9f9f9 100%)`,
-        borderRadius: '0px',
+        background: bgColor,
+        borderRadius: 0,
         width: '100%',
         height: '100%',
         boxSizing: 'border-box',
         overflow: 'hidden',
-        boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)',
-        border: '1px solid rgba(0, 0, 0, 0.05)'
+        //boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)',
+        border: noBorder ? 'none' : `${borderWidth} solid ${borderColor}`
       }}
     >
       {sections.map((sec, idx) => (

--- a/my-web-builder/apps/frontend/src/pages/components/definitions/map_info.json
+++ b/my-web-builder/apps/frontend/src/pages/components/definitions/map_info.json
@@ -1,25 +1,54 @@
 {
-    "type": "mapInfo",
-    "label": "장소 안내",
-    "defaultProps": {
-      "sections": [
-        {
-          "header": "지하철 안내",
-          "content": "예: 7호선 학동역 8번 출구 도보 10분"
-        },
-        {
-          "header": "버스 안내",
-          "content": "예: 간선버스: 147, 241 / 지선버스: 4211, 4412"
-        },
-        {
-          "header": "주차 안내",
-          "content": "예: 건물 뒤 공용주차장 / 최대 2시간 무료"
-        },
-        {
-            "header":"네비게이션",
-            "content":"예: '세창웨딩'또는 '세창웨딩홀'또는 주소입력"
-        }
-      ]
+  "type": "mapInfo",
+  "label": "장소 안내",
+  "props": {
+    "noBorder": {
+      "type": "boolean",
+      "label": "테두리 제거",
+      "default": true
+    },
+    "borderColor": {
+      "type": "color",
+      "label": "테두리 색상",
+      "default": "#e5e7eb"
+    },
+    "borderWidth": {
+      "type": "select",
+      "label": "테두리 두께",
+      "options": ["1px", "2px", "3px", "4px"],
+      "default": "1px"
+    },
+    "borderRadius": {
+      "type": "number",
+      "label": "모서리 둥글기",
+      "min": 0,
+      "max": 50,
+      "default": 8,
+      "suffix": "px"
     }
+  },
+  "defaultProps": {
+    "noBorder": true,
+    "borderColor": "#e5e7eb",
+    "borderWidth": "1px",
+    "borderRadius": 8,
+    "sections": [
+      {
+        "header": "지하철 안내",
+        "content": "예: 7호선 학동역 8번 출구 도보 10분"
+      },
+      {
+        "header": "버스 안내",
+        "content": "예: 간선버스: 147, 241 / 지선버스: 4211, 4412"
+      },
+      {
+        "header": "주차 안내",
+        "content": "예: 건물 뒤 공용주차장 / 최대 2시간 무료"
+      },
+      {
+        "header": "네비게이션",
+        "content": "예: '세창웨딩'또는 '세창웨딩홀'또는 주소입력"
+      }
+    ]
   }
-  
+}


### PR DESCRIPTION
## 📋 PR 요약

지도안내 컴포넌트 테두리 제거 추가

## 📋 Issue 번호

- close #368 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

지도안내 컴포넌트 "테두리 제거" 추가
기존 배경색이 "아주 연한 회색" + "그라데이션" + "그림자" 되어있었음 -> 흰색 배경으로 설정함

## 📎 스크린샷

<img width="415" height="494" alt="스크린샷 2025-07-14 194148" src="https://github.com/user-attachments/assets/ba15c012-f044-47f9-b314-d021f670283c" />
<img width="381" height="502" alt="스크린샷 2025-07-14 194154" src="https://github.com/user-attachments/assets/55503956-680b-4df9-b5b8-2b3acca68712" />
<img width="282" height="332" alt="스크린샷 2025-07-14 194200" src="https://github.com/user-attachments/assets/bb61e6fd-f1d5-44fe-bf4b-1123325c9bde" />
<img width="291" height="265" alt="스크린샷 2025-07-14 194204" src="https://github.com/user-attachments/assets/0bb3fc3b-f8fa-4465-a6d8-bd2475222ed0" />
<img width="453" height="482" alt="스크린샷 2025-07-14 194211" src="https://github.com/user-attachments/assets/70a57be8-133d-4c70-8f10-db53645eee49" />
