### PR TITLE
음악 이모티콘 수정

### DIFF
--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/MusicEditor.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/MusicEditor.jsx
@@ -121,7 +121,7 @@ export default function MusicEditor({ selectedComp, onUpdate }) {
                                     marginLeft: 8
                                 }}
                             >
-                                {isPreviewPlaying && previewMusicId === music.id ? '⏹' : '▶'}
+                                {isPreviewPlaying && previewMusicId === music.id ? '■' : '▶'}
                             </button>
                         </div>
                     ))}

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/MusicRenderer.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/MusicRenderer.jsx
@@ -94,7 +94,7 @@ export default function MusicRenderer({ comp, isEditor = false, mode = 'editor' 
                     padding: 0
                 }}
             >
-                {isPlaying ? '⏸' : '▶'}
+                {isPlaying ? '❚❚' : '▶'}
             </button>
         </div>
     );

--- a/my-web-builder/apps/subdomain-nextjs/components/renderers/MusicRenderer.jsx
+++ b/my-web-builder/apps/subdomain-nextjs/components/renderers/MusicRenderer.jsx
@@ -94,7 +94,7 @@ export default function MusicRenderer({ comp, isEditor = false, mode = 'live' })
                     padding: 0
                 }}
             >
-                {isPlaying ? '⏸' : '▶'}
+                {isPlaying ? '❚❚' : '▶'}
             </button>
         </div>
     );


### PR DESCRIPTION
## 📋 PR 요약

음악 "일시정지", "정지" 이모티콘 수정

## 📋 Issue 번호

- close #382 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

브라우저/운영체제/폰트에 따라 이모티콘이 이미지처럼 보이지 않고, SVG 또는 네이티브 아이콘(파란 네모)으로 대체 렌더링될 수 있다고 함
이는 코드 문제가 아니라, 유니코드 이모티콘의 렌더링 방식(폰트/OS 차이) 때문이라고 함
"일시정지", "정지"를 더 단순한 유니코드 기호를 사용해서 해결함


## 📎 스크린샷
<img width="267" height="52" alt="스크린샷 2025-07-15 024404" src="https://github.com/user-attachments/assets/d3999053-faf4-4a6c-9db2-92dd6270110d" />
<img width="113" height="101" alt="스크린샷 2025-07-15 024410" src="https://github.com/user-attachments/assets/0f691098-dcdd-452f-8328-df6472b43a70" />
