### PR TITLE
이미지 컴포넌트 드래그 문제 수정

### DIFF
--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/ImageRenderer.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/ImageRenderer.jsx
@@ -249,6 +249,7 @@ function ImageRenderer({ comp, component, isEditor = false, mode = 'editor', isP
         alt={actualComp?.props?.alt || '이미지'}
         onLoad={handleImageLoad}
         onError={handleImageError}
+        draggable={false}
         style={{
           width: '100%',
           height: '100%',

--- a/my-web-builder/apps/subdomain-nextjs/next-env.d.ts
+++ b/my-web-builder/apps/subdomain-nextjs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/my-web-builder/apps/subdomain-nextjs/next-env.d.ts
+++ b/my-web-builder/apps/subdomain-nextjs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
## 📋 PR 요약

이미지 컴포넌트 드래그 문제 수정

## 📋 Issue 번호

- close #398 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

draggable={false} 한 줄 추가

밑에는 GPT 설명

<img> 태그는 기본적으로 draggable="true" 속성이 적용되어 있습니다.
브라우저는 이미지를 드래그하면 자체적으로 "드래그 프리뷰"를 띄우고, 드래그 이벤트를 처리합니다.
이때 React에서 관리하는 드래그 상태와 브라우저의 기본 드래그가 충돌할 수 있습니다.
그래서 드래그 종료 이벤트가 정상적으로 전달되지 않거나,
드래그 상태가 초기화되지 않는 문제가 발생할 수 있습니다.

## 📎 스크린샷
