### PR TITLE
Fix WebSocket mixed content error: Use WSS for all environments

### DIFF
--- a/my-web-builder/apps/frontend/src/config.js
+++ b/my-web-builder/apps/frontend/src/config.js
@@ -67,7 +67,7 @@ export const API_BASE_URL = getEnvVar('VITE_API_URL') || getEnvVar('VITE_API_BAS
 
 // Y.js WebSocket 서버 설정 - 환경변수 기반
 export const YJS_WEBSOCKET_URL = getEnvVar('VITE_YJS_WEBSOCKET_URL') || getEnvVar('VITE_WEBSOCKET_URL') || getEnvVar('NEXT_PUBLIC_YJS_WEBSOCKET_URL') ||
-  (isProductionEnvironment() ? 'wss://13.124.221.182:1235' : `ws://${getLocalNetworkIP()}:1234`);
+  (isProductionEnvironment() ? 'wss://13.124.221.182:1235' : 'wss://13.124.221.182:1235');
 
 
 


### PR DESCRIPTION
- Changed YJS_WEBSOCKET_URL to always use wss://13.124.221.182:1235
- Resolves mixed content security error when HTTPS page tries to connect to WS endpoint
- Ensures secure WebSocket connection for both local and production environments

## 📋 PR 요약

<!-- 작업 내용 한 줄로 요약 -->

## 📋 Issue 번호

- close # 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

## 📎 스크린샷
