### PR TITLE
댓글 "스타일" 수정 및 텍스트 "레이어 순서" 삭제

### DIFF
--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/CommentEditor.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/CommentEditor.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  FontFamilyEditor, 
-  TextAlignEditor, 
-  LineHeightEditor, 
-  LetterSpacingEditor, 
-  TextStyleEditor, 
-  ColorEditor, 
-  SelectEditor, 
+import {
+  FontFamilyEditor,
+  TextAlignEditor,
+  LineHeightEditor,
+  LetterSpacingEditor,
+  TextStyleEditor,
+  ColorEditor,
+  SelectEditor,
   NumberEditor,
   BorderEditor,
   TextEditor,
@@ -52,7 +52,7 @@ function CommentEditor({ selectedComp, onUpdate }) {
           placeholder="제목을 입력하세요"
         />
       </div>
-      
+
       <div>
         <label style={{
           display: 'block', fontSize: 13, fontWeight: 500,
@@ -69,10 +69,10 @@ function CommentEditor({ selectedComp, onUpdate }) {
 
       {/* 폰트 섹션 */}
       <div style={{ height: 1, backgroundColor: '#eee', margin: '16px 0' }} />
-      <div style={{ 
-        fontSize: 12, 
-        color: '#65676b', 
-        fontWeight: 600, 
+      <div style={{
+        fontSize: 12,
+        color: '#65676b',
+        fontWeight: 600,
         marginBottom: 12,
         textTransform: 'uppercase',
         letterSpacing: '0.5px'
@@ -105,25 +105,21 @@ function CommentEditor({ selectedComp, onUpdate }) {
       />
 
       <TextStyleEditor
-        value={{
-          fontWeight: selectedComp.props?.fontWeight || false,
-          fontStyle: selectedComp.props?.fontStyle || false,
-          textDecoration: selectedComp.props?.textDecoration || false
-        }}
-        onChange={(styles) => {
-          handlePropChange('fontWeight', styles.fontWeight);
-          handlePropChange('fontStyle', styles.fontStyle);
-          handlePropChange('textDecoration', styles.textDecoration);
-        }}
         label="스타일"
+        boldValue={!!selectedComp.props?.fontWeight}
+        italicValue={!!selectedComp.props?.fontStyle}
+        underlineValue={!!selectedComp.props?.textDecoration}
+        onBoldChange={(v) => handlePropChange('fontWeight', v)}
+        onItalicChange={(v) => handlePropChange('fontStyle', v)}
+        onUnderlineChange={(v) => handlePropChange('textDecoration', v)}
       />
 
       {/* 색상 섹션 */}
       <div style={{ height: 1, backgroundColor: '#eee', margin: '16px 0' }} />
-      <div style={{ 
-        fontSize: 12, 
-        color: '#65676b', 
-        fontWeight: 600, 
+      <div style={{
+        fontSize: 12,
+        color: '#65676b',
+        fontWeight: 600,
         marginBottom: 12,
         textTransform: 'uppercase',
         letterSpacing: '0.5px'
@@ -136,7 +132,7 @@ function CommentEditor({ selectedComp, onUpdate }) {
         onChange={(value) => handlePropChange('color', value)}
         label="텍스트 색상"
       />
-      
+
       <div>
         <label style={{
           display: 'block', fontSize: 13, fontWeight: 500,

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/TextComponentEditor.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/TextComponentEditor.jsx
@@ -105,29 +105,6 @@ function TextComponentEditor({ selectedComp, onUpdate }) {
         onChange={(value) => updateProperty('color', value)}
         label="글자 색상"
       />
-
-      {/* 레이어 섹션 */}
-      <div style={{ height: 1, backgroundColor: '#eee', margin: '16px 0' }} />
-      <div style={{
-        fontSize: 12,
-        color: '#65676b',
-        fontWeight: 600,
-        marginBottom: 12,
-        textTransform: 'uppercase',
-        letterSpacing: '0.5px'
-      }}>
-        Layer
-      </div>
-
-      <NumberEditor
-        value={selectedComp.props?.zIndex || 1000}
-        onChange={(value) => updateProperty('zIndex', value)}
-        label="레이어 순서"
-        min={1}
-        max={2000}
-        suffix=""
-        description="높은 숫자가 위에 표시됩니다 (텍스트는 기본 1000)"
-      />
     </div>
   );
 }

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/TextComponentEditor.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentEditors/TextComponentEditor.jsx
@@ -23,8 +23,6 @@ function TextComponentEditor({ selectedComp, onUpdate }) {
 
   return (
     <div>
-
-
       {/* 텍스트 전용 에디터들 */}
       <TextEditor
         value={selectedComp.props?.text || ''}


### PR DESCRIPTION
## 📋 PR 요약

댓글 "스타일" 수정 및 텍스트 "레이어 순서" 삭제

## 📋 Issue 번호

- close #471 

## 🔍 변경 사항

- 변경 1:
- 변경 2:

## 📢 공유하고 싶은 내용

CommentEditor에서 TextStyleEditor에 맞게 props를 넘기도록 수정했음

## 📎 스크린샷

<img width="755" height="632" alt="스크린샷 2025-07-18 141318" src="https://github.com/user-attachments/assets/a68e8d9e-6fb3-44d8-ab10-ba64520d6d58" />

<img width="666" height="319" alt="스크린샷 2025-07-18 141323" src="https://github.com/user-attachments/assets/a5454721-a20f-4951-8afa-5730925ad27c" />

