### PR TITLE
fix: GitHub Actions에서 WebSocket URL을 도메인 기반으로 변경

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -33,7 +33,7 @@ jobs:
           cd my-web-builder/apps/frontend
           rm -f .env.production
           echo "VITE_API_URL=https://ddukddak.org/api" > .env.production
-          echo "VITE_YJS_WEBSOCKET_URL=wss://43.203.235.108:1235" >> .env.production
+          echo "VITE_YJS_WEBSOCKET_URL=wss://ws.ddukddak.org:1235" >> .env.production
  
           echo "VITE_SUBDOMAIN_URL=http://3.35.141.231:3001" >> .env.production
           echo "VITE_GOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}" >> .env.production


### PR DESCRIPTION
## 📋 PR 요약

fix: GitHub Actions에서 WebSocket URL을 도메인 기반으로 변경


