### PR TITLE
모바일 -> 데스크톱 가운데 정렬, 캘린더 서브도메인 수정

### DIFF
--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/ImageRenderer.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/ImageRenderer.jsx
@@ -219,8 +219,6 @@ function ImageRenderer({ comp, component, isEditor = false, mode = 'editor', isP
           color: '#6b7280',
           fontSize: '14px'
         }}>
-          <div style={{ fontSize: '20px', marginBottom: '8px' }}>⏳</div>
-          <div>로딩 중...</div>
         </div>
       )}
 

--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/PreviewRenderer.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/PreviewRenderer.jsx
@@ -207,6 +207,12 @@ const PreviewRenderer = ({
       if (editingViewport === 'desktop') {
         const newScale = currentWidth / BASE_DESKTOP_WIDTH;
         setDesktopScale(newScale);
+      } else if (editingViewport === 'mobile') {
+        // 편집 기준이 모바일일 때 데스크톱에서 보면 적절한 크기로 보여주기
+        // 데스크톱 너비의 1/3 정도 크기로 제한
+        const maxWidth = Math.min(currentWidth * 0.33, BASE_MOBILE_WIDTH);
+        const newScale = maxWidth / BASE_MOBILE_WIDTH;
+        setMobileScale(newScale);
       }
     }
   }, [containerWidth, forcedViewport, editingViewport]);
@@ -279,9 +285,21 @@ const PreviewRenderer = ({
         0,
         ...componentsToRender.map((c) => (c.y || 0) + (c.height || 0))
       ) + PAGE_VERTICAL_PADDING; // 하단 여백 추가
+
+    // 편집 기준이 모바일일 때 데스크톱에서 보면 가운데 정렬
+    const isMobileEditingInDesktopView =
+      editingViewport === 'mobile' && forcedViewport !== 'mobile';
+
     return (
       <div
-        style={{ width: '100%', height: `${contentHeight * mobileScale}px` }}
+        style={{
+          width: '100%',
+          height: `${contentHeight * mobileScale}px`,
+          display: 'flex',
+          justifyContent: isMobileEditingInDesktopView
+            ? 'center'
+            : 'flex-start',
+        }}
       >
         <div
           style={{
@@ -325,7 +343,16 @@ const PreviewRenderer = ({
     const currentEditingMode = editingViewport || 'desktop';
 
     if (currentEditingMode === 'mobile') {
-      return renderMobileScalingLayout(components);
+      // 편집 기준이 모바일일 때도 데스크톱에서 보면 가운데 정렬
+      const centeredComponents = components.map((comp) => ({
+        ...comp,
+        x:
+          comp.x +
+          (BASE_MOBILE_WIDTH -
+            (comp.width || getComponentDefaultSize(comp.type).width)) /
+            2,
+      }));
+      return renderMobileScalingLayout(centeredComponents);
     } else {
       const componentGroups = groupComponentsByVerticalStacks(
         components,
@@ -425,7 +452,7 @@ const PreviewRenderer = ({
       className={isMobileView ? 'hide-scrollbar' : ''}
     >
       {containerWidth > 0
-        ? isMobileView
+        ? isMobileView || editingViewport === 'mobile'
           ? renderMobileLayout()
           : renderDesktopLayout()
         : null}

--- a/my-web-builder/apps/subdomain-nextjs/components/renderers/CalendarRenderer.jsx
+++ b/my-web-builder/apps/subdomain-nextjs/components/renderers/CalendarRenderer.jsx
@@ -1,37 +1,36 @@
 import React from 'react';
 
 function CalendarRenderer({ comp, mode = 'live' }) {
-  // 컨테이너 크기 기준으로 스케일 팩터 계산
-  const baseWidth = 375; // 기준 너비
-  const actualWidth = comp.width || baseWidth;
-  const scaleFactor = actualWidth / baseWidth;
-  
-  const { 
-    weddingDate, 
-    title, 
-    highlightColor,
+  console.log('CalendarRenderer props:', comp.props);
+  console.log('CalendarRenderer comp:', comp);
+
+  const {
+    weddingDate,
+    title,
+    highlightColor = '#ff6b9d',
     noBorder = true,
     borderColor = '#e5e7eb',
     borderWidth = '1px',
     borderRadius = 0,
+    weddingDateLabel = 'Wedding Date:',
   } = comp.props;
-  
+
   // 날짜 파싱
   const targetDate = new Date(weddingDate);
   const currentDate = new Date();
   const year = targetDate.getFullYear();
   const month = targetDate.getMonth();
   const day = targetDate.getDate();
-  
+
   // 달력 생성 로직
   const firstDay = new Date(year, month, 1);
   const lastDay = new Date(year, month + 1, 0);
   const startDate = new Date(firstDay);
   startDate.setDate(startDate.getDate() - firstDay.getDay());
-  
+
   const weeks = [];
   const currentWeekDate = new Date(startDate);
-  
+
   for (let week = 0; week < 6; week++) {
     const days = [];
     for (let day = 0; day < 7; day++) {
@@ -41,127 +40,154 @@ function CalendarRenderer({ comp, mode = 'live' }) {
     weeks.push(days);
     if (currentWeekDate > lastDay && currentWeekDate.getDay() === 0) break;
   }
-  
+
   const monthNames = [
-    'January', 'February', 'March', 'April', 'May', 'June',
-    'July', 'August', 'September', 'October', 'November', 'December'
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
   ];
-  
+
   const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-  
+
   return (
-    <div style={{
-      width: mode === 'live' ? '100%' : `${comp?.width || 300}px`,
-      height: mode === 'live' ? `${(comp?.height || 300) * scaleFactor}px` : `${comp?.height || 200}px`,
-      backgroundColor: 'white',
-      border: noBorder ? 'none' : `${borderWidth} solid ${borderColor}`,
-      borderRadius: mode === 'live' ? `${borderRadius * scaleFactor}px` : borderRadius,
-      boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
-      display: 'flex',
-      flexDirection: 'column',
-      minHeight: mode === 'live' ? `${300 * scaleFactor}px` : '300px',
-      padding: mode === 'live' ? `${16 * scaleFactor}px` : '16px',
-      boxSizing: 'border-box'
-    }}>
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'white',
+        border: noBorder ? 'none' : `${borderWidth} solid ${borderColor}`,
+        borderRadius: borderRadius,
+        //boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: '300px',
+        padding: '16px',
+        boxSizing: 'border-box',
+      }}
+    >
       {title && (
-        <h3 style={{
-          fontSize: mode === 'live' ? `${18 * scaleFactor}px` : '18px',
-          fontWeight: '600',
-          textAlign: 'center',
-          marginBottom: mode === 'live' ? `${16 * scaleFactor}px` : '16px',
-          color: '#1f2937'
-        }}>
+        <h3
+          style={{
+            fontSize: '18px',
+            fontWeight: '600',
+            textAlign: 'center',
+            marginBottom: '16px',
+            color: '#1f2937',
+          }}
+        >
           {title}
         </h3>
       )}
-      
+
       {/* 월/년 헤더 */}
-      <div style={{ textAlign: 'center', marginBottom: mode === 'live' ? `${16 * scaleFactor}px` : '16px' }}>
-        <h4 style={{
-          fontSize: mode === 'live' ? `${20 * scaleFactor}px` : '20px',
-          fontWeight: 'bold',
-          color: '#374151'
-        }}>
+      <div style={{ textAlign: 'center', marginBottom: '16px' }}>
+        <h4
+          style={{
+            fontSize: '20px',
+            fontWeight: 'bold',
+            color: '#374151',
+          }}
+        >
           {monthNames[month]} {year}
         </h4>
       </div>
-      
+
       {/* 요일 헤더 */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(7, 1fr)',
-        gap: mode === 'live' ? `${4 * scaleFactor}px` : '4px',
-        marginBottom: mode === 'live' ? `${8 * scaleFactor}px` : '8px'
-      }}>
-        {dayNames.map(dayName => (
-          <div key={dayName} style={{
-            textAlign: 'center',
-            fontSize: mode === 'live' ? `${14 * scaleFactor}px` : '14px',
-            fontWeight: '500',
-            color: '#6b7280',
-            padding: mode === 'live' ? `${8 * scaleFactor}px 0` : '8px 0'
-          }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(7, 1fr)',
+          gap: '4px',
+          marginBottom: '8px',
+        }}
+      >
+        {dayNames.map((dayName) => (
+          <div
+            key={dayName}
+            style={{
+              textAlign: 'center',
+              fontSize: '14px',
+              fontWeight: '500',
+              color: '#6b7280',
+              padding: '8px 0',
+            }}
+          >
             {dayName}
           </div>
         ))}
       </div>
-      
+
       {/* 달력 날짜들 */}
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(7, 1fr)',
-        gap: mode === 'live' ? `${4 * scaleFactor}px` : '4px',
-        flex: 1
-      }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(7, 1fr)',
+          gap: '4px',
+          flex: 1,
+        }}
+      >
         {weeks.map((week, weekIndex) =>
           week.map((date, dayIndex) => {
             const isCurrentMonth = date.getMonth() === month;
-            const isWeddingDay = date.getDate() === day && date.getMonth() === month && date.getFullYear() === year;
+            const isWeddingDay =
+              date.getDate() === day &&
+              date.getMonth() === month &&
+              date.getFullYear() === year;
             const isToday = date.toDateString() === currentDate.toDateString();
-            
+
+            let cellStyle = {
+              height: '40px',
+              width: '40px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              fontSize: '14px',
+              borderRadius: borderRadius,
+              cursor: 'pointer',
+              color: !isCurrentMonth ? '#d1d5db' : '#374151',
+              backgroundColor: isWeddingDay ? highlightColor : 'transparent',
+              fontWeight: isWeddingDay || isToday ? 'bold' : 'normal',
+              position: 'relative',
+              border: isToday && !isWeddingDay ? '2px solid #d1d5db' : 'none', // 연한 회색 테두리
+              boxSizing: 'border-box',
+            };
+
             return (
-              <div
-                key={`${weekIndex}-${dayIndex}`}
-                style={{
-                  height: mode === 'live' ? `${40 * scaleFactor}px` : '40px',
-                  width: mode === 'live' ? `${40 * scaleFactor}px` : '40px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: mode === 'live' ? `${14 * scaleFactor}px` : '14px',
-                  borderRadius: mode === 'live' ? `${8 * scaleFactor}px` : '8px',
-                  cursor: 'pointer',
-                  color: !isCurrentMonth ? '#d1d5db' : '#374151',
-                  backgroundColor: isWeddingDay ? highlightColor : 
-                                 isToday ? '#dbeafe' : 'transparent',
-                  fontWeight: isWeddingDay || isToday ? 'bold' : 'normal',
-                  position: 'relative'
-                }}
-              >
+              <div key={`${weekIndex}-${dayIndex}`} style={cellStyle}>
                 {date.getDate()}
                 {isWeddingDay && (
-                  <div style={{
-                    position: 'absolute',
-                    marginTop: mode === 'live' ? 'clamp(24px, 6vw, 32px)' : '32px',
-                    fontSize: mode === 'live' ? 'clamp(10px, 2.5vw, 12px)' : '12px',
-                    textAlign: 'center'
-                  }}>
-                    💒
-                  </div>
+                  <span
+                    style={{
+                      position: 'absolute',
+                      bottom: 2,
+                      left: '50%',
+                      transform: 'translateX(-50%)',
+                      fontSize: '16px',
+                      pointerEvents: 'none',
+                    }}
+                    aria-label="Wedding Day"
+                  ></span>
                 )}
               </div>
             );
           })
         )}
       </div>
-      
-      {/* 웨딩 날짜 표시 */}
-      <div style={{ marginTop: mode === 'live' ? 'clamp(12px, 3vw, 16px)' : '16px', textAlign: 'center' }}>
-        <div style={{ 
-          fontSize: mode === 'live' ? 'clamp(12px, 3vw, 14px)' : '14px', 
-          color: '#6b7280' 
-        }}>
-          Wedding Date: <span style={{ fontWeight: '600', color: highlightColor }}>
+
+      {/* 날짜 표시 */}
+      <div style={{ marginTop: '16px', textAlign: 'center' }}>
+        <div style={{ fontSize: '14px', color: '#6b7280' }}>
+          {weddingDateLabel}{' '}
+          <span style={{ fontWeight: '600', color: highlightColor }}>
             {targetDate.toLocaleDateString('en-US')}
           </span>
         </div>

--- a/my-web-builder/apps/subdomain-nextjs/components/renderers/ImageRenderer.jsx
+++ b/my-web-builder/apps/subdomain-nextjs/components/renderers/ImageRenderer.jsx
@@ -137,8 +137,6 @@ function ImageRenderer({ comp, onUpdate, mode = 'live', width, height }) {
           textAlign: 'center',
           color: '#666'
         }}>
-          <div>⏳</div>
-          <div>로딩 중...</div>
         </div>
       )}
 

--- a/my-web-builder/apps/subdomain-nextjs/next-env.d.ts
+++ b/my-web-builder/apps/subdomain-nextjs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## 📋 PR 요약

모바일 -> 데스크톱 가운데 정렬, 캘린더 서브도메인 수정

## 📎 스크린샷

<img width="2988" height="1838" alt="image" src="https://github.com/user-attachments/assets/99a696a6-bf17-4865-bdf1-fbb353b8048e" />
