### PR TITLE
모바일 뷰 렌더링 이슈 개선

### DIFF
--- a/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/SlidoRenderer.jsx
+++ b/my-web-builder/apps/frontend/src/pages/NoCodeEditor/ComponentRenderers/SlidoRenderer.jsx
@@ -279,7 +279,6 @@ function SlidoRenderer({ comp, isEditor = false, mode = 'editor', pageId }) {
 
       if (response.ok) {
         const data = await response.json();
-        console.log('🚀 SlidoRenderer - API 응답 데이터:', data);
         setOpinions(data);
 
         // 의견 그룹 업데이트

--- a/my-web-builder/apps/subdomain-nextjs/components/renderers/CalendarRenderer.jsx
+++ b/my-web-builder/apps/subdomain-nextjs/components/renderers/CalendarRenderer.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
 function CalendarRenderer({ comp, mode = 'live' }) {
-  console.log('CalendarRenderer props:', comp.props);
-  console.log('CalendarRenderer comp:', comp);
 
   const {
     weddingDate,

--- a/my-web-builder/apps/subdomain-nextjs/components/renderers/SlidoRenderer.jsx
+++ b/my-web-builder/apps/subdomain-nextjs/components/renderers/SlidoRenderer.jsx
@@ -268,7 +268,6 @@ function SlidoRenderer({ comp, pageId, mode = 'live', width, height }) {
 
       if (response.ok) {
         const data = await response.json();
-        console.log('🚀 SlidoRenderer - API 응답 데이터:', data);
         setOpinions(data);
 
         // 의견 그룹 업데이트


### PR DESCRIPTION
## 📋 PR 요약
- 모든 화면 크기에서 컴포넌트가 정확히 중앙 정렬됨
- 375px 이상에서도 컴포넌트가 화면 크기에 맞게 확대됨
- 375px 이하에서 컴포넌트가 짤리지 않고 정상적으로 축소됨
